### PR TITLE
fix: change keyring `ServiceName` to camel case

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -82,7 +82,7 @@ func newCachingTokenProviderUsingKeyring(issuer, clientID, audience string, with
 
 func getK8sKeyringSetup() (keyring.Keyring, error) {
 	return keyring.Open(keyring.Config{
-		ServiceName:              "k8s-pixy-auth",
+		ServiceName:              "K8sPixyAuth",
 		KeychainName:             "k8s-pixy-auth",
 		KeychainTrustApplication: true,
 		FilePasswordFunc:         k8sTerminalPrompt,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This patch changes  the `Freedesktop.SecretService` service name
to be compatible with `Freedesktop Dbus` specification.

See: https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names

When using `Freedesktop.SecretService` as secret backend. The collection
created will be the same as the service name, and character `-` will be
converted to `_2d` when caching the token, however when retrieving the
token the collection name expected will still be `k8s-pixy-auth`.
Therefore `k8s-pixy-auth` will not find the cached token and start the
authentication journey again.


### References

Fixes #24 

### Testing

1. Using freedesktop secret service backend in a Linux OS, like Fedora 30

2. configure the K8S cluster according to the guide,

3. configure the kubeconfig file according the guide,

4. execute kubectl get nodes ---> browser auth -> successful result

5. execute kubectl get nodes  -> successful result

The cached token was used to execute `kubectl` without browser auth a second time. 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
