### PR TITLE
change token API requests to satisfy RFC

### DIFF
--- a/auth/authorization_tokenretriever.go
+++ b/auth/authorization_tokenretriever.go
@@ -67,16 +67,18 @@ func (ce *TokenRetriever) newExchangeCodeRequest(req AuthorizationCodeExchangeRe
 	uv.Set("code", req.Code)
 	uv.Set("redirect_uri", req.RedirectURI)
 
+	euv := uv.Encode()
+
 	request, err := http.NewRequest("POST",
 		ce.oidcWellKnownEndpoints.TokenEndpoint,
-		strings.NewReader(uv.Encode()),
+		strings.NewReader(euv),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Add("Content-Length", strconv.Itoa(len(uv.Encode())))
+	request.Header.Add("Content-Length", strconv.Itoa(len(euv)))
 
 	return request, nil
 }
@@ -89,16 +91,18 @@ func (ce *TokenRetriever) newRefreshTokenRequest(req RefreshTokenExchangeRequest
 	uv.Set("client_id", req.ClientID)
 	uv.Set("refresh_token", req.RefreshToken)
 
+	euv := uv.Encode()
+
 	request, err := http.NewRequest("POST",
 		ce.oidcWellKnownEndpoints.TokenEndpoint,
-		strings.NewReader(uv.Encode()),
+		strings.NewReader(euv),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	request.Header.Add("Content-Length", strconv.Itoa(len(uv.Encode())))
+	request.Header.Add("Content-Length", strconv.Itoa(len(euv)))
 
 	return request, nil
 }

--- a/auth/authorization_tokenretriever_test.go
+++ b/auth/authorization_tokenretriever_test.go
@@ -23,18 +23,18 @@ var _ = Describe("CodetokenExchanger", func() {
 
 			result, err := tokenRetriever.newExchangeCodeRequest(exchangeRequest)
 
-			var tokenRequest AuthorizationTokenRequest
-			json.NewDecoder(result.Body).Decode(&tokenRequest)
+			result.ParseForm()
 
 			Expect(err).To(BeNil())
-			Expect(tokenRequest).To(Equal(AuthorizationTokenRequest{
-				GrantType:    "authorization_code",
-				ClientID:     "clientID",
-				CodeVerifier: "Verifier",
-				Code:         "code",
-				RedirectURI:  "https://redirect",
-			}))
+			Expect(result.FormValue("grant_type")).To(Equal("authorization_code"))
+			Expect(result.FormValue("client_id")).To(Equal("clientID"))
+			Expect(result.FormValue("code_verifier")).To(Equal("Verifier"))
+			Expect(result.FormValue("code")).To(Equal("code"))
+			Expect(result.FormValue("redirect_uri")).To(Equal("https://redirect"))
 			Expect(result.URL.String()).To(Equal("https://issuer/oauth/token"))
+
+			Expect(result.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
+			Expect(result.Header.Get("Content-Length")).To(Equal("117"))
 		})
 
 		It("returns an error when NewRequest returns an error", func() {
@@ -96,16 +96,16 @@ var _ = Describe("CodetokenExchanger", func() {
 
 			result, err := tokenRetriever.newRefreshTokenRequest(exchangeRequest)
 
-			var tokenRequest RefreshTokenRequest
-			json.NewDecoder(result.Body).Decode(&tokenRequest)
+			result.ParseForm()
 
 			Expect(err).To(BeNil())
-			Expect(tokenRequest).To(Equal(RefreshTokenRequest{
-				GrantType:    "refresh_token",
-				ClientID:     "clientID",
-				RefreshToken: "refreshToken",
-			}))
+			Expect(result.FormValue("grant_type")).To(Equal("refresh_token"))
+			Expect(result.FormValue("client_id")).To(Equal("clientID"))
+			Expect(result.FormValue("refresh_token")).To(Equal("refreshToken"))
 			Expect(result.URL.String()).To(Equal("https://issuer/oauth/token"))
+
+			Expect(result.Header.Get("Content-Type")).To(Equal("application/x-www-form-urlencoded"))
+			Expect(result.Header.Get("Content-Length")).To(Equal("70"))
 		})
 
 		It("returns an error when NewRequest returns an error", func() {


### PR DESCRIPTION
### Description
We were using JSON to send token requests when the RFC explicitly says to use `application/x-www-form-urlencoded`. This PR fixes that discrepancy.

### References
Fix for #20.

### Testing
Unit tests were added and it was manually tested using Minikube and Auth0.