### PR TITLE
Allow authorization flow to open a browser on Windows.

### DIFF
--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -1,11 +1,14 @@
 package os
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
 	"runtime"
+	"strings"
 )
 
 // DefaultInteractor is the default OS interactor that wraps go standard os
@@ -19,14 +22,28 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 
 	switch runtime.GOOS {
 	case "windows":
+		// The character & is treated as running a separate command in Windows
+		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
+		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
+		// cmd /c start 'http://domain.com?param1"&"param2' works when inputting directly to the command prompt,
+		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
+		// And spaces will not work within the string we need to encode only the whitespace.
+		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell
+		// to allow the browser to be opened for auth.
+		tmpfile := []byte(fmt.Sprintf("start '%s'", strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `"&"`)))
+		if err := ioutil.WriteFile("browser-signin.ps1", tmpfile, 0644); err != nil {
+			return err
+		}
 		cmd = "cmd"
-		args = []string{"/c", "start"}
+		args = []string{"/c", "Powershell", ".\\browser-signin.ps1"}
 	case "darwin":
 		cmd = "open"
+		args = append(args, url)
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
+		args = append(args, url)
 	}
-	args = append(args, url)
+
 	return exec.Command(cmd, args...).Start()
 }
 

--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -1,9 +1,7 @@
 package os
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -22,27 +20,22 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 
 	switch runtime.GOOS {
 	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
 		// The character & is treated as running a separate command in Windows
 		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
 		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
 		// cmd /c start 'http://domain.com?param1=value with space"&"param2=value2' works when inputting directly to the command prompt,
 		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
-		// And spaces will not work within the string we need to encode only the whitespace.
-		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell
-		// to allow the browser to be opened for auth.
-		tmpfile := []byte(fmt.Sprintf("start '%s'", strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `"&"`)))
-		if err := ioutil.WriteFile("browser-signin.ps1", tmpfile, 0644); err != nil {
-			return err
-		}
-		cmd = "cmd"
-		args = []string{"/c", "Powershell", ".\\browser-signin.ps1"}
+		// The start command uses ^ to escape special characters
+		url = strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `^&`)
 	case "darwin":
 		cmd = "open"
-		args = append(args, url)
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
-		args = append(args, url)
 	}
+
+	args = append(args, url)
 
 	return exec.Command(cmd, args...).Start()
 }

--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -25,7 +25,7 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 		// The character & is treated as running a separate command in Windows
 		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
 		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
-		// cmd /c start 'http://domain.com?param1"&"param2' works when inputting directly to the command prompt,
+		// cmd /c start 'http://domain.com?param1=value with space"&"param2=value2' works when inputting directly to the command prompt,
 		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
 		// And spaces will not work within the string we need to encode only the whitespace.
 		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

- The character & is treated as running a separate command in Windows
- cmd /c start "http://domain.com?param1=value with spaces&param2=value2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
- Also, the " char is used as the delimiter to escape special characters, so "&" would become &\
- cmd /c start 'http://domain.com?param1=value with spaces"&"param2=value2' works when inputting directly to the command prompt, but the "&" is - escaped by "&" when passed from code, which becomes &, resulting in cmd /c start 'http://domain.com?param1\&\param2'
- And spaces will not work within the string we need to encode only the whitespace.
- __This code creates the correct URL string, adds the start command to a Powershell file and executes Powershell to allow the browser to be opened for auth.__

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

Fixes #30 

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

The issue I created #30 outlines the steps to reproduce both the issue and the working code.

There wasn't any go tests for this particular file.

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
