### PR TITLE
WSL Command Support

### DIFF
--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -1,11 +1,14 @@
 package os
 
 import (
+	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
 	"runtime"
+	"strings"
 )
 
 // DefaultInteractor is the default OS interactor that wraps go standard os
@@ -19,14 +22,28 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 
 	switch runtime.GOOS {
 	case "windows":
+		// The character & is treated as running a separate command in Windows
+		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
+		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
+		// cmd /c start 'http://domain.com?param1"&"param2' works when inputting directly to the command prompt,
+		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
+		// And spaces will not work within the string we need to encode only the whitespace.
+		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell
+		// to allow the browser to be opened for auth.
+		tmpfile := []byte(fmt.Sprintf("start '%s'", strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `"&"`)))
+		if err := ioutil.WriteFile("browser-signin.ps1", tmpfile, 0644); err != nil {
+			return err
+		}
 		cmd = "cmd"
-		args = []string{"/c", "start"}
+		args = []string{"/c", "Powershell", ".\\browser-signin.ps1"}
 	case "darwin":
 		cmd = "open"
+		args = append(args, url)
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
+		args = append(args, url)
 	}
-	args = append(args, url)
+
 	return exec.Command(cmd, args...).Start()
 }
 

--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -1,7 +1,6 @@
 package os
 
 import (
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -105,8 +104,7 @@ func (i DefaultInteractor) CopyFile(source, destination string) error {
 func (i DefaultInteractor) IsWSL() bool {
 	b, err := exec.Command("uname", "-a").Output()
 	if err != nil {
-		fmt.Printf("\nWarning: %s\n", err.Error())
-		return false
+		panic(err)
 	}
 
 	if strings.Contains(strings.ToLower(string(b)), "microsoft") {

--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -1,9 +1,7 @@
 package os
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -22,27 +20,22 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 
 	switch runtime.GOOS {
 	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start"}
 		// The character & is treated as running a separate command in Windows
 		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
 		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
 		// cmd /c start 'http://domain.com?param1=value with space"&"param2=value2' works when inputting directly to the command prompt,
 		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
-		// And spaces will not work within the string we need to encode only the whitespace.
-		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell
-		// to allow the browser to be opened for auth.
-		tmpfile := []byte(fmt.Sprintf("start '%s'", strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `"&"`)))
-		if err := ioutil.WriteFile("browser-signin.ps1", tmpfile, 0644); err != nil {
-			return err
-		}
-		cmd = "cmd"
-		args = []string{"/c", "Powershell", ".\\browser-signin.ps1"}
+		// The start command uses ^ to escape special characters
+		url = strings.ReplaceAll(strings.ReplaceAll(url, " ", "%20"), "&", `^&`)
 	case "darwin":
 		cmd = "open"
-		args = append(args, url)
 	default: // "linux", "freebsd", "openbsd", "netbsd"
 		cmd = "xdg-open"
-		args = append(args, url)
 	}
+
+	args = append(args, url)
 
 	return exec.Command(cmd, args...).Start()
 }

--- a/os/os_interactor.go
+++ b/os/os_interactor.go
@@ -25,7 +25,7 @@ func (i *DefaultInteractor) OpenURL(url string) error {
 		// The character & is treated as running a separate command in Windows
 		// cmd /c start "http://domain.com?param1&param2" results in trying to run cmd /c "start http://domain.com?parm1" & param2
 		// Also, the " char is used as the delimiter to escape special characters, so "&" would become \&\
-		// cmd /c start 'http://domain.com?param1"&"param2' works when inputting directly to the command prompt,
+		// cmd /c start 'http://domain.com?param1=value with space"&"param2=value2' works when inputting directly to the command prompt,
 		// but the "&" is escaped by \"&\" when passed from code, which becomes \&\, resulting in cmd /c start 'http://domain.com?param1\&\param2'
 		// And spaces will not work within the string we need to encode only the whitespace.
 		// SO, this code creates the correct URL string, adds the start command to a powershell file and executes powershell


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

With Windows SubSystem for Linux becoming very popular, some additional checks would be needed to account for it as the "xdg-open" command does not work. However, cmd.exe /c start ... is supported.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

Fixes #32 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

```
/mnt/c$ ./k8s-pixy-auth auth   --issuer-endpoint "https://ISSUER.COM"   --audience "AUDIENCE"   --client-id "CLIENTID"   --use-id-token
in the future you can set KEYRING_K8S_PIXY_AUTH_PASSWORD to bypass this prompt
Enter passphrase to unlock /home/traviisd/.k8s-pixy-auth: {"kind":"ExecCredential","apiVersion":"client.authentication.k8s.io/v1beta1","spec":{},"status":{"token":"THE JWT YAY!"}}
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
